### PR TITLE
feat!: move to root

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,50 +1,11 @@
-# Python - venv package
+# Python - venv package GitHub Action
 
-- This pipeline is designed to export a venv package for the specified Python version with the installed requirements.
+This repository provides a reusable GitHub Action for creating a venv package for the specified Python version with the installed requirements.
 When [Poetry](https://python-poetry.org/) is used, the requirements will be exported and the requirements will be installed in the venv.
-- The pipeline is designed to be as generic as possible, so they can be easily reused in any project.
-- This repository is a part of the generic GitHub Actions pipeline collection that can be used in any project.
 
 ## Usage
 
-Here are basic examples of how you can integrate it in your project.
-
-<details>
-  <summary>Example workflow</summary>
-
-This workflow is executed automatically on push of tags.
-
-In the code below you need to replace the `<python_version>` and `<package_file_name>`. See the [configuration section](#configuration).
-
-```yml
-name: Build Python project
-
-on:
-  push:
-    tags:
-      - v*
-
-jobs:
-  venv-package:
-    runs-on: ubuntu-latest
-    steps:
-      # Using the action
-      - name: Build venv package
-        uses: minvws/action-python-venv-package/.github/actions/python-venv-package@main
-        with:
-          python_version: <python_version>
-          package_file_name: <package_file_name>
-
-```
-
-</details>
-
-<details>
-  <summary>Example workflow self checkout</summary>
-
-This workflow is executed automatically on the push of tags. The workflow will check out the repo and the action won't. Now it is possible to run additional actions before using the venv package action.
-
-In the code below you need to replace the `<python_version>` and `<package_file_name>`. See the [configuration section](#configuration).
+To use the action, add it to a workflow in your repository:
 
 ```yml
 name: Build Python project
@@ -61,27 +22,28 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      # Using the action
       - name: Build venv package
-        uses: minvws/action-python-venv-package/.github/actions/python-venv-package@main
+        uses: minvws/action-python-venv-package@v1
         with:
           python_version: <python_version>
           package_file_name: <package_file_name>
-          checkout_repository: 'false'
+          checkout_repository: "false"
 ```
 
-</details>
+Replace `<python_version>` with the Python version your project needs and replace `<package_file_name>` with the desired name for the package. See [Configuration](#configuration) for details.
+
+In this basic example, the workflow is executed automatically on push of tags.
 
 ### Configuration
 
 The action has inputs. The inputs are:
 
-- python_version: Semver version of the Python version you want to use. For example `3.11` or `3.9`.
-- package_file_name: File name for the venv package. For example `nl-example-package`.
-- checkout_repository: Boolean value inside string to enable or disable checkout repository
-  in the action. For example `'true'` or `'false'`. Default `'true'`.
-- working_directory: Directory containing the Python project. The directory should contain
-  a `requirements.txt` file or a `pyproject.toml` file. Default `'.'`.
+- `python_version`: Which version of Python version to use. For example `"3.11"` or `">=3.9 <3.14"`.
+- `package_file_name`: File name for the venv package. For example `nl-example-package`.
+- `checkout_repository`: Boolean value inside string to enable or disable checkout repository
+  in the action. For example `"true"` or `"false"`. Default `"true"`.
+- `working_directory`: Directory containing the Python project. The directory should contain
+  a `requirements.txt` file or a `pyproject.toml` file. Default `"."`.
 
 ### Result
 
@@ -95,3 +57,11 @@ The uploaded artifact will have a limited lifetime depending on what is currentl
 
 If you want to contribute a new pipeline, please check the reusable workflow guidelines in the
 [GitHub documentation](https://docs.github.com/en/actions/using-workflows/reusing-workflows#creating-a-reusable-workflow).
+
+## License
+
+This repository is released under the EUPL 1.2 license. See [LICENSE.txt](./LICENSE.txt) for details.
+
+## Part of iCore
+
+This package is part of the iCore project.

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,6 @@
-name: "Python venv packager"
+name: "Create Python venv package"
 description: "Exports a Python venv package with the needed requirements installed"
+
 inputs:
   python_version:
     description: "Python version"


### PR DESCRIPTION
Move the action to the root and update the docs accordingly, instructing users to use `minvws/action-python-venv-package@v1` instead of `minvws/action-generic-build-package/.github/actions/action-python-venv-package@main`.
